### PR TITLE
Fix chart versioning

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: far-edge-node-watcher
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.5
-appVersion: 0.0.2
+version: 0.0.4
+appVersion: 0.0.1

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ''
 image:
   repository: ghcr.io/fraunhoferportugal/fita/components/far-edge-node-watcher
   pullPolicy: Always
-  tag: 0.0.2
+  tag: 0.0.1
 imagePullSecrets: []
 farEdgeKubelet:
   image:


### PR DESCRIPTION
## Description
The previous stopped release would publish a new app version without any changes to far-edge-node-watcher.
This PR fixes version mismatch and triggers the release that only updates chart values, patching its version.