### PR TITLE
Feature/tls

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -97,7 +97,6 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.nodeSelector }}
       volumes:
         - name: trust-bundle
           configMap:
@@ -105,6 +104,7 @@ spec:
         - name: fenw-mqtt-client-tls
           secret:
             secretName: fenw-mqtt-client-secret
+      {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -38,6 +38,12 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: trust-bundle
+              mountPath: /etc/ssl/fita
+              readOnly: true
+            - name: fenw-mqtt-client-tls
+              mountPath: /etc/ssl/mqtt-client
           command: [ "python3", "-u", "main.py" ]
           args:
             - --mqtt_uri={{ include "missing.required" (dict "Message" "MQTT broker host is required" "Value" .Values.mqttBroker.host) }}
@@ -92,6 +98,13 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
+      volumes:
+        - name: trust-bundle
+          configMap:
+            name: trust-bundle-confmap
+        - name: fenw-mqtt-client-tls
+          secret:
+            secretName: fenw-mqtt-client-secret
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -110,10 +110,18 @@ spec:
       volumes:
         - name: trust-bundle
           configMap:
+          {{- if .Values.mqttBroker.trustBundleConfigMap }}
+            name: {{ .Values.mqttBroker.trustBundleConfigMap }}
+          {{- else }}
             name: fita-trust-bundle
+          {{- end }}
         - name: fenw-mqtt-client-tls
           secret:
+          {{- if .Values.mqttBroker.tlsClientSecret }}
+            secretName: {{ .Values.mqttBroker.tlsClientSecret }}
+          {{- else }}
             secretName: fenw-mqtt-client-secret
+          {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -38,17 +38,26 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if or (.Values.mqttBroker.serverTLS) (.Values.mqttBroker.mutualTLS) }}
           volumeMounts:
             - name: trust-bundle
               mountPath: /etc/ssl/fita
               readOnly: true
             - name: fenw-mqtt-client-tls
               mountPath: /etc/ssl/mqtt-client
+              readOnly: true
+          {{- end }}
           command: [ "python3", "-u", "main.py" ]
           args:
             - --mqtt_uri={{ include "missing.required" (dict "Message" "MQTT broker host is required" "Value" .Values.mqttBroker.host) }}
             - --mqtt_port={{ .Values.mqttBroker.port }}
             - --mqtt_client_id={{ .Values.mqttBroker.clientId }}
+          {{- if .Values.mqttBroker.serverTLS }}
+            - --mqtt_server_tls
+          {{- end }}
+          {{- if .Values.mqttBroker.mutualTLS }}
+            - --mqtt_mutual_tls
+          {{- end }}
             - --kubelet_image={{ .Values.farEdgeKubelet.image.repository }}:{{ .Values.farEdgeKubelet.image.tag }}
             - --image_pull_policy={{ .Values.farEdgeKubelet.image.pullPolicy }}
             - --local_registry_path={{ .Values.farEdgeKubelet.registry.localRegistry }}
@@ -97,6 +106,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if or (.Values.mqttBroker.serverTLS) (.Values.mqttBroker.mutualTLS) }}
       volumes:
         - name: trust-bundle
           configMap:
@@ -104,6 +114,7 @@ spec:
         - name: fenw-mqtt-client-tls
           secret:
             secretName: fenw-mqtt-client-secret
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
       volumes:
         - name: trust-bundle
           configMap:
-            name: trust-bundle-confmap
+            name: fita-trust-bundle
         - name: fenw-mqtt-client-tls
           secret:
             secretName: fenw-mqtt-client-secret

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -39,6 +39,8 @@ mqttBroker:
   clientId: far-edge-node-watcher
   serverTLS: false
   mutualTLS: false # this is an upgrade over the previous
+  trustBundleConfigMap: fita-trust-bundle
+  tlsClientSecret: fenw-mqtt-client-secret
 podAnnotations: {}
 podLabels: {}
 podSecurityContext:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -37,6 +37,8 @@ mqttBroker:
   host: ''
   port: 1883
   clientId: far-edge-node-watcher
+  serverTLS: false
+  mutualTLS: false # this is an upgrade over the previous
 podAnnotations: {}
 podLabels: {}
 podSecurityContext:

--- a/nextgengw/main.py
+++ b/nextgengw/main.py
@@ -6,6 +6,7 @@ import time
 import json
 import sys
 import os
+import ssl
 import argparse
 
 import traceback
@@ -354,6 +355,8 @@ def main():
   parser.add_argument('--mqtt_uri', help='MQTT Broker URI', required=True)
   parser.add_argument('--mqtt_port', help='MQTT Broker Port', required=True)
   parser.add_argument('--mqtt_client_id', help='MQTT Broker Client ID', required=True)
+  parser.add_argument('--mqtt_server_tls', default=False, help='Whether to use tls with broker certificate', action='store_true', required=False)
+  parser.add_argument('--mqtt_mutual_tls', default=False, help='Whether to use tls with broker and client certificates', action='store_true', required=False)
 
   parser.add_argument('--kubelet_image', help='Image name for the Far Edge Kubelet', required=True)
   parser.add_argument('--image_pull_secret', help="Name of the registry credentials used to pull the far-edge kubelet image", default=[], action='append', dest="image_pull_secrets")
@@ -372,10 +375,16 @@ def main():
 
   # parse the command line arguments
   args = parser.parse_args()
+  if args.mqtt_server_tls or args.mqtt_mutual_tls:
+      port = 8883
+  else:
+      port = args.mqtt_port
 
   print(f'mqtt_uri={args.mqtt_uri}')
-  print(f'mqtt_port={args.mqtt_port}')
+  print(f'mqtt_port={port}')
   print(f'mqtt_client_id={args.mqtt_client_id}')
+  print(f'mqtt_server_tls={args.mqtt_server_tls}')
+  print(f'mqtt_mutual_tls={args.mqtt_mutual_tls}')
   print(f'kubelet_image={args.kubelet_image}')
   print(f'local_registry_path={args.local_registry_path}')
   print(f'remote_registry_url={args.remote_registry_url}')
@@ -400,17 +409,32 @@ def main():
 
   not_connected = True
   i = 0
+  if args.mqtt_mutual_tls:
+      print("Mutual TLS setup")
+      client.tls_set(ca_certs="/etc/ssl/fita/ca.crt", keyfile="/etc/ssl/mqtt-client/tls.key", certfile="/etc/ssl/mqtt-client/tls.crt")
+  elif args.mqtt_server_tls:
+      print("TLS setup")
+      client.tls_set(ca_certs="/etc/ssl/fita/ca.crt")
+
   while not_connected:
     try:
-      client.connect(args.mqtt_uri, int(args.mqtt_port))
-      not_connected = False
+      if args.mqtt_server_tls or args.mqtt_mutual_tls:
+        print("attempting tls connection")
+        client.connect(args.mqtt_uri, 8883)
+        not_connected = False
+        print("Successfully connected with tls encryption")
+      else:
+        print("attempting normal connection")
+        client.connect(args.mqtt_uri, int(args.mqtt_port))
+        not_connected = False
+        print("Successfully connected")
     
     except ConnectionRefusedError:
       print("MQTT broker not ready. Retrying in 5 seconds. Retry number " + str(i))
       i = i+1
     
     except Exception as e: # client.connect raises a different exception when uri name can't be resolved causing the node-watcher to crash
-      print(e)
+      print(f"TLS/connection error ({type(e).__name__}): {e}")
       print("MQTT broker: Name does not resolve. Incorrect broker Name or MQTT broker not ready. Retrying in 5 seconds...")
       i = i+1
     


### PR DESCRIPTION
## Description
This pull request contains the implementation of mTLS and TLS support for the Far-Edge Node Watcher. It allows FENW to authenticate the mqtt broker based on a trust Root CA mounted to /etc/ssl/fita, and authenticate itself to the broker using its client certificate chain.

Related issues: 
- none afaik

## Checklist
- [x] Code compiles locally
- [x] Added/updated tests where applicable
- [ ] Unit tests pass (not available for Python in Makefile)
- [ ] Code follows linting/formatting rules (`make lint` and `make format` don't report issues) (not available for Python in Makefile)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] CI / tooling change

## Additional Notes
This support is not mandatory, and is not enabled by default. It is integrated with the Helm charts and easily toggled between NoSec, TLS and mTLS. It pressuposes the use of trust-manager and cert-manager and certain naming conventions for the certificate and trust bundles with Fita, but realistically you can mount the necessary certificates to the pod with any other mechanism with very little tweaks.